### PR TITLE
デプロイ用のブランチ

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,3 @@ end
 group :production do
   gem "pg", "1.3.5"
 end
-
-# Windows ではタイムゾーン情報用の tzinfo-data gem を含める必要があります
-#gem "tzinfo-data", platforms: %i[ mingw mswin x64_mingw jruby ]


### PR DESCRIPTION
CodeSpace上で作成したブランチが何故かGitHub上で存在しないことになっていたため、
急遽CodeSpace上のソースを新規ブランチとして自動作成させました。

デプロイ用に何も設定を変えていないため、コメントアウトを削除することで差分を発生させコミット。